### PR TITLE
Add shell auto-completion to conda package

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,4 +24,6 @@ else
        mkdir -p $PREFIX/etc/conda/${i}.d
        cp $RECIPE_DIR/${i}.sh $PREFIX/etc/conda/${i}.d/${PKG_NAME}.sh
    done
+
+   cp etc/hub*completion* $PREFIX/etc
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   folder: src/github.com/github/hub
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Adds the hub auto-complete scripts [under `/etc`](https://github.com/github/hub/tree/master/etc) to the conda package.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
